### PR TITLE
Use CARGO_REGISTRY_TOKEN instead of 'cargo login'

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,6 +49,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Publish release to crates
         run: |
-          cargo login ${{ secrets.CARGO_TOKEN }}
-          cargo publish -p cylinder
-          cargo publish -p cyl
+          CARGO_REGISTRY_TOKEN=${{ secrets.CARGO_TOKEN }} cargo publish -p cylinder
+          CARGO_REGISTRY_TOKEN=${{ secrets.CARGO_TOKEN }} cargo publish -p cyl


### PR DESCRIPTION
This prevents the token from being written to the filesystem.