### PR TITLE
Fix clippy clippy::uninlined-format-args lint

### DIFF
--- a/cli/src/commands/jwt_generate.rs
+++ b/cli/src/commands/jwt_generate.rs
@@ -36,7 +36,7 @@ pub(crate) fn handle_jwt_generate(key_name: Option<String>) -> Result<(), CliErr
         CliError::from_source_with_message(Box::new(err), "failed to build json web token".into())
     })?;
 
-    println!("{}", encoded_token);
+    println!("{encoded_token}");
 
     Ok(())
 }

--- a/cli/src/error/cli.rs
+++ b/cli/src/error/cli.rs
@@ -86,7 +86,7 @@ impl error::Error for CliError {
 impl fmt::Display for CliError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.message {
-            Some(m) => write!(f, "{}", m),
+            Some(m) => write!(f, "{m}"),
             None => match &self.source {
                 Some(s) => match &s.prefix {
                     Some(p) => write!(f, "{}: {}", p, s.source),
@@ -100,7 +100,7 @@ impl fmt::Display for CliError {
 
 impl fmt::Debug for CliError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -41,7 +41,7 @@ pub(crate) fn configure_logging(log_level: i8) {
         // `FlexiLoggerError::Log` means the logger has already been initialized; this will happen
         // when `run` is called more than once in the tests.
         Err(flexi_logger::FlexiLoggerError::Log(_)) => {}
-        Err(err) => panic!("Failed to start logger: {}", err),
+        Err(err) => panic!("Failed to start logger: {err}"),
     }
 }
 

--- a/libcylinder/src/hex.rs
+++ b/libcylinder/src/hex.rs
@@ -23,7 +23,7 @@ use std::error::Error;
 pub fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>, HexError> {
     for (i, ch) in s.chars().enumerate() {
         if !ch.is_ascii_hexdigit() {
-            return Err(HexError(format!("invalid character position {}", i)));
+            return Err(HexError(format!("invalid character position {i}")));
         }
     }
 
@@ -42,7 +42,7 @@ pub fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>, HexError> {
 /// Converts the given bytes to a hex string
 pub fn bytes_to_hex_str(b: &[u8]) -> String {
     b.iter()
-        .map(|b| format!("{:02x}", b))
+        .map(|b| format!("{b:02x}"))
         .collect::<Vec<_>>()
         .join("")
 }

--- a/libcylinder/src/jwt/mod.rs
+++ b/libcylinder/src/jwt/mod.rs
@@ -321,7 +321,7 @@ impl<'a> JsonWebTokenParser<'a> {
         let verified = self
             .verifier
             .verify(
-                format!("{}.{}", encoded_header, encoded_claims).as_bytes(),
+                format!("{encoded_header}.{encoded_claims}").as_bytes(),
                 &Signature::new(signature_bytes),
                 &public_key,
             )

--- a/libcylinder/src/key/load.rs
+++ b/libcylinder/src/key/load.rs
@@ -188,12 +188,12 @@ pub fn load_key_from_path(path: &Path) -> Result<PrivateKey, KeyLoadError> {
             Ok(key) => Ok(key),
             Err(e) => Err(KeyLoadError::with_source(
                 Box::new(e),
-                &format!("Unable to load key from path: {:?}", path),
+                &format!("Unable to load key from path: {path:?}"),
             )),
         },
         Err(err) => Err(KeyLoadError::with_source(
             Box::new(err),
-            &format!("Unable to open key file: {:?}", path),
+            &format!("Unable to open key file: {path:?}"),
         )),
     }
 }
@@ -221,10 +221,7 @@ fn load_key_from_file(file: File) -> Result<PrivateKey, KeyLoadError> {
         Some(key) => PrivateKey::new_from_hex(key.trim()).map_err(|err| {
             KeyLoadError::with_source(Box::new(err), "unable to create private key from hex")
         }),
-        None => Err(KeyLoadError::new(&format!(
-            "Empty key file: {:?}",
-            key_file
-        ))),
+        None => Err(KeyLoadError::new(&format!("Empty key file: {key_file:?}"))),
     }
 }
 


### PR DESCRIPTION
This new lint requires inlining variables in format strings.
